### PR TITLE
update @metamask/onboarding version

### DIFF
--- a/start/package.json
+++ b/start/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "",
   "dependencies": {
-    "@metamask/onboarding": "^0.2.1"
+    "@metamask/onboarding": "^1.0.1"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^2.0.0",


### PR DESCRIPTION
The older ^0.2.1 grabs an older version of the library from NPM possibly. In it Metamask is used instead of MetaMask